### PR TITLE
AZ-DOP-1309: Add variables custom_service_endpoints, custom_enforce_private_links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v2.3.0 - 2020-10-02
+
+Added
+  * AZ-DOP-1309: Add a parameter to set a custom `service_endpoints` by subnet.
+  * AZ-DOP-1309: Add a parameter to set a custom `enforce_private_link_endpoint_network_policies` by subnet.
+
+Changed
+  * AZ-DOP-1309: Update README
+
 # v2.2.0 - 2020-03-27
 
 Added

--- a/README.md
+++ b/README.md
@@ -104,7 +104,9 @@ module "azure-network-subnet" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
+| custom\_enforce\_private\_links | The Enable or Disable network policies customed map for the private link endpoint on the subnets | `map(bool)` | `null` | no |
 | client\_name | Client name/account used in naming | `string` | n/a | yes |
+| custom\_service\_endpoints |The list of Service endpoints customed map to associate with the subnets | `map(list(string))` | `null` | no |
 | custom\_subnet\_names | Optional custom subnet names | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
 | enforce\_private\_link | Enable or Disable network policies for the private link endpoint on the subnet | `bool` | `false` | no |
 | environment | Project environment | `string` | n/a | yes |

--- a/resources.tf
+++ b/resources.tf
@@ -1,3 +1,14 @@
+
+# resource "null_resource" "subnetdatasource" {
+#   count = length(var.subnet_cidr_list)
+#   triggers = {
+#     name = coalesce(
+#       element(var.custom_subnet_names, count.index),
+#       length(var.subnet_cidr_list) == 1 ? local.subnet_name : "${local.subnet_name}${count.index}",
+#     )
+#   }
+# }
+
 resource "azurerm_subnet" "subnet" {
   count = length(var.subnet_cidr_list)
 
@@ -5,6 +16,7 @@ resource "azurerm_subnet" "subnet" {
     element(var.custom_subnet_names, count.index),
     length(var.subnet_cidr_list) == 1 ? local.subnet_name : "${local.subnet_name}${count.index}",
   )
+
   resource_group_name  = var.resource_group_name
   virtual_network_name = var.virtual_network_name
   address_prefix       = element(var.subnet_cidr_list, count.index)
@@ -15,9 +27,29 @@ resource "azurerm_subnet" "subnet" {
     ignore_changes = [route_table_id, network_security_group_id]
   }
 
-  service_endpoints = var.service_endpoints
+  service_endpoints = coalesce(
+    lookup(
+      coalesce(var.custom_service_endpoints, {}),
+      coalesce(
+        element(var.custom_subnet_names, count.index),
+        length(var.subnet_cidr_list) == 1 ? local.subnet_name : "${local.subnet_name}${count.index}",
+      ),
+      null
+    ),
+    var.service_endpoints,
+  )
 
-  enforce_private_link_endpoint_network_policies = var.enforce_private_link
+  enforce_private_link_endpoint_network_policies = coalesce(
+    lookup(
+      coalesce(var.custom_enforce_private_links, {}),
+      coalesce(
+        element(var.custom_subnet_names, count.index),
+        length(var.subnet_cidr_list) == 1 ? local.subnet_name : "${local.subnet_name}${count.index}",
+      ),
+      null
+    ),
+    var.enforce_private_link
+  )
 }
 
 resource "azurerm_subnet_network_security_group_association" "subnet_association" {

--- a/terraform.tfvars.ci
+++ b/terraform.tfvars.ci
@@ -6,3 +6,4 @@ resource_group_name="rg-test"
 virtual_network_name="vnet-test"
 subnet_cidr_list=["10.10.0.0/24"]
 service_endpoints=["Microsoft.AzureActiveDirectory","Microsoft.AzureCosmosDB"]
+custom_service_endpoints={vnet-test=["Microsoft.AzureActiveDirectory","Microsoft.AzureCosmosDB"]}

--- a/variables.tf
+++ b/variables.tf
@@ -68,3 +68,15 @@ variable "enforce_private_link" {
   type        = bool
   default     = false
 }
+
+variable "custom_service_endpoints" {
+  description = "The list of Service endpoints customed map to associate with the subnets"
+  type        = map(list(string))
+  default     = null
+}
+
+variable "custom_enforce_private_links" {
+  description = "The Enable or Disable network policies customed map for the private link endpoint on the subnets"
+  type        = map(bool)
+  default     = null
+}


### PR DESCRIPTION
Issue #2 AZ-DOP-1309: Add variables custom_service_endpoints, custom_enforce_private_links

respectively

- to set custom service_endpoints and by subnet

- to set custom enforce_private_link_endpoint_network_policies by subnet.

### Branched v2.3.x from tag v2.2.0 
The merge is related to make improvements on the basis of the tag v2.2.0 that matches my current terraform and azurerm versions. So conflit are to be solved later to also move this changes to master branch. 

### Example:

Provided the local.subnets as

```
    subnets = [
      {
        name = "VDC1-Snet-Flux-INT",
        cidr = ".....",
      },

      {
        name = "GatewaySubnet",
        cidr = "....."
      },
      {
        name                 = "VDC1-Snet-Algo-Data-INT",
        cidr                 = "192.168.50.176/28",
        enforce_private_link = true,
      },
      {
        name = ".....",
        cidr = ".....",
      },
      {
        name              = "VDC1-Snet-Algo-Engine-INT",
        cidr              = "192.168.50.224/27",
        service_endpoints = ["Microsoft.Sql", ],
      },
      {
        name = ".....",
        cidr = ".....",
      },
    ]
```

I can the set the new custom variables custom_enforce_private_links, custom_service_endpoints for my subnet module, with no breaking change like this: 

```
  custom_enforce_private_links = {
    for eachsubnet in local.vnet_int.subnets : eachsubnet.name => lookup(eachsubnet, "enforce_private_link", false)
  }
```
```
  custom_service_endpoints = {
    for eachsubnet in local.vnet_int.subnets : eachsubnet.name => lookup(eachsubnet, "service_endpoints", [])
  }
```